### PR TITLE
Filled calendar_page. Calendar appears on the app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,7 @@ void main() async {
           ),
           body: const TabBarView(
             children: [
-              Calendar(),
-              DayPage(),
+              CalendarPage(),
               Recipe(),
             ],
           ),

--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -1,15 +1,52 @@
 import 'package:flutter/material.dart';
+import 'package:noorish_app/pages/day_page.dart';
 
-class Calendar extends StatefulWidget {
-  const Calendar({super.key});
+class CalendarPage extends StatelessWidget {
+    const CalendarPage({super.key});
 
-  @override
-  State<Calendar> createState() => _CalendarState();
-}
-
-class _CalendarState extends State<Calendar> {
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Calendar'),
+      ),
+      body: GridView.builder(
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 7,
+        ),
+        itemCount: 31, // 7x5 grid
+        itemBuilder: (context, index) {
+          // Adding 1 to index since you may want to start the calendar from day 1
+          int dayNumber = index + 1;
+          return GestureDetector(
+            onTap: () {
+              _openDayPage(context, dayNumber);
+            },
+            child: Container(
+              alignment: Alignment.center,
+              margin: EdgeInsets.all(5),
+              decoration: BoxDecoration(
+                color: Colors.blue[100],
+                borderRadius: BorderRadius.circular(5),
+              ),
+              child: Text(
+                '$dayNumber',
+                style: TextStyle(fontSize: 18),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _openDayPage(BuildContext context, int dayNumber) {
+    // Navigate to the corresponding day page
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => DayPage(dayNumber: dayNumber),
+      ),
+    );
   }
 }

--- a/lib/pages/day_page.dart
+++ b/lib/pages/day_page.dart
@@ -10,7 +10,9 @@ import 'package:noorish_app/pages/add_meals_page.dart';
 import 'package:noorish_app/style.dart';
 
 class DayPage extends StatefulWidget {
-  const DayPage({super.key});
+  final int dayNumber;
+
+  const DayPage({required this.dayNumber});
 
   @override
   State<DayPage> createState() => _DayPageState();


### PR DESCRIPTION
DayPage() is removed from main because it is called in the calendar_page.dart file. DayPage() must also take in a number as a parameter to help navigate the calendar whenever a widget is clicked.